### PR TITLE
0.2: TypeId now passed by value and path provided to named types 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.0
+
+- Provide a `path` iterator to composite, variant and sequence callbacks in `ResolveTypeVisitor`, so that people can access the path/name of these types. The path is also exposed in the concrete visitor implementation.
+- Make `TypeId` be passed by value and not lifetime. This is done because:
+  1. `scale-info` uses a `TypeId = u32`, so it does not matter either way, and
+  2. `scale-info-legacy` uses `TypeId = TypeName`, and needs to modify the `TypeName`s provided back in some cases, making pass-by-reference impossible.
+
 # 0.1.1
 
 Just a patch release to make a small addition and no API changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scale-type-resolver"
 description = "A low level trait to be generic over how to resolve SCALE type information"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/src/portable_registry.rs
+++ b/src/portable_registry.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{
-    BitsOrderFormat, BitsStoreFormat, Field, Primitive, ResolvedTypeVisitor, TypeResolver, Variant
+    BitsOrderFormat, BitsStoreFormat, Field, Primitive, ResolvedTypeVisitor, TypeResolver, Variant,
 };
 use core::iter::ExactSizeIterator;
 use scale_info::{form::PortableForm, PortableRegistry};
@@ -78,7 +78,9 @@ impl TypeResolver for PortableRegistry {
             scale_info::TypeDef::Variant(variant) => {
                 visitor.visit_variant(path_iter, iter_variants(&variant.variants))
             }
-            scale_info::TypeDef::Sequence(seq) => visitor.visit_sequence(path_iter, seq.type_param.id),
+            scale_info::TypeDef::Sequence(seq) => {
+                visitor.visit_sequence(path_iter, seq.type_param.id)
+            }
             scale_info::TypeDef::Array(arr) => {
                 visitor.visit_array(arr.type_param.id, arr.len as usize)
             }


### PR DESCRIPTION
- Provide a `path` iterator to composite, variant and sequence callbacks in `ResolveTypeVisitor`, so that people can access the path/name of these types. The path is also exposed in the concrete visitor implementation.
- Make `TypeId` be passed by value and not lifetime. This is done because:
  1. `scale-info` uses a `TypeId = u32`, so it does not matter either way, and
  2. `scale-info-legacy` uses `TypeId = TypeName`, and needs to modify the `TypeName`s provided back in some cases, making pass-by-reference impossible.

When this is released, this initial `scale-info-legacy` PR, which is what motivated these changes, will be about ready to go:
- https://github.com/paritytech/scale-info-legacy/pull/1

I've also made branches to test updating this in the various crates that depend on it, and all seems ok:
- https://github.com/paritytech/subxt/compare/jsdw-type-resolver-0.2?expand=1
- https://github.com/paritytech/scale-value/compare/jsdw-type-resolver-0.2?expand=1
- https://github.com/paritytech/scale-encode/compare/jsdw-type-resolver-0.2?expand=1
- https://github.com/paritytech/scale-decode/compare/jsdw-type-resolver-0.2?expand=1

Once this is released, I'll turn those into proper PRs to release them, too, then get the `scale-info-legacy` PR out. 